### PR TITLE
Added video-live event to wait for video load

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npm run dev
 | notsupported   | error    | emitted when the browser does not support this feature        |
 | cameras        | cameras  | emitted when a list of all cameras available is loaded        |
 | camera-change  | deviceId | emitted when camera change occurs                             |
+| video-live     | stream   | emitted when video is started                                 |
 
 ### Methods
 

--- a/src/webcam.vue
+++ b/src/webcam.vue
@@ -128,6 +128,10 @@ export default {
         // old broswers
         this.source = window.HTMLMediaElement.srcObject(stream);
       }
+      // Emit video start/live event
+      this.$refs.video.onloadedmetadata = () => {
+        this.$emit('video-live', stream);
+      };
 
       this.$emit('started', stream);
     },


### PR DESCRIPTION
In our case we show web-cam only after a user presses a button and this causes the delay between start and actual video load.

started event fires successfully, but there's around 1 second delay. After that the actual video is started - it seems that this happens due to the webcam itself takes some time to initialise.

So for us the solution was to add additional event for video stream to load - we show a loader until it does.
Probably this will be helpful to others.