### PR TITLE
Call stop in beforeDestroy lifecycle hook

### DIFF
--- a/src/webcam.vue
+++ b/src/webcam.vue
@@ -59,6 +59,9 @@ export default {
   mounted() {
     this.setupMedia();
   },
+  beforeDestroy(){
+    this.stop();
+  },
   methods: {
     legacyGetUserMediaSupport() {
       return constraints => {


### PR DESCRIPTION
This is to prevent camera from staying on when the vue-web-cam component is destroyed.